### PR TITLE
Pretty print expressions so sequences of multiplications are shown as powers

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -1,0 +1,29 @@
+# I don't know how to test the plotting code in unit tests, so I am turning coverage off 
+# until I figure out how to.
+
+# nocov start 
+
+#' @export
+plot.units <- function(x, y, xlab = NULL, ylab = NULL, ...) {
+  # We define the axis labels if they are not already provided and then let
+  # the default plotting function take over...
+  if (is.null(xlab)) {
+    xlab <- paste0(deparse(substitute(x)), " [", as.character(units(x)), "]")
+  }
+  if (is.null(ylab) && inherits(y, "units")) {
+    ylab <- paste0(deparse(substitute(y)), " [", as.character(units(y)), "]")
+  }
+  NextMethod("plot", xlab = xlab, ylab = ylab)
+}
+
+#' @export
+hist.units <- function(x, xlab = NULL, ...) {
+  # We define the axis labels if they are not already provided and then let
+  # the default plotting function take over...
+  if (is.null(xlab)) {
+    xlab <- paste0(deparse(substitute(x)), " [", as.character(units(x)), "]")
+  }
+  NextMethod("hist", xlab = xlab)
+}
+
+# nocov end

--- a/tests/testthat/test_arith.R
+++ b/tests/testthat/test_arith.R
@@ -47,8 +47,8 @@ test_that("we can take powers of units", {
   
   expect_equal(as.numeric(ux ** 2), x ** 2)
   expect_equal(as.numeric(ux ^ 2), x ^ 2)
-  expect_equal(as.character(units(ux ** 2)), "m*m")
-  expect_equal(as.character(units(ux ^ 2)), "m*m")
+  expect_equal(as.character(units(ux ** 2)), "m^2")
+  expect_equal(as.character(units(ux ^ 2)), "m^2")
   
   expect_error(ux ^ 1.3)
   expect_error(ux ^ 0.3)
@@ -57,8 +57,8 @@ test_that("we can take powers of units", {
   
   expect_equal(as.numeric(ux ** -2), x ** -2)
   expect_equal(as.numeric(ux ^ -2), x ^ -2)
-  expect_equal(as.character(units(ux ** -2)), "1/m/m")
-  expect_equal(as.character(units(ux ^ -2)), "1/m/m")
+  expect_equal(as.character(units(ux ** -2)), "1/m^2")
+  expect_equal(as.character(units(ux ^ -2)), "1/m^2")
   
   expect_equal(as.numeric(ux ** 0), x ** 0)
   expect_equal(as.numeric(ux ^ 0), x ^ 0)
@@ -85,7 +85,7 @@ test_that("we can convert units and simplify after multiplication", {
   expect_equal(as.numeric(ux*uz), x*z)
   expect_equal(as.character(units(ux*uz)), "km*m")
   expect_equal(as.numeric(as.units(ux*uz, km * km)), (x/1000)*z)
-  expect_equal(as.character(units(as.units(ux*uz, km * km))), "km*km")
+  expect_equal(as.character(units(as.units(ux*uz, km * km))), "km^2")
   
   expect_equal(as.numeric(ux/ux), x/x)
   expect_equal(as.character(units(ux/ux)), "1")

--- a/tests/testthat/test_symbolic_units.R
+++ b/tests/testthat/test_symbolic_units.R
@@ -9,9 +9,9 @@ test_that("we can make symbolic units", {
 test_that("we can multiply and divide symbolic units", {
   m <- units:::.make_symbolic_units("m")
   s <- units:::.make_symbolic_units("s")
-  expect_equal(as.character(units(m*m)), "m*m")
+  expect_equal(as.character(units(m*m)), "m^2")
   expect_equal(as.character(units(m/s)), "m/s")
-  expect_equal(as.character(units(units(m/s)/s)), "m/s/s")
+  expect_equal(as.character(units(units(m/s)/s)), "m/s^2")
 })
 
 test_that("we can simplify basic units", {


### PR DESCRIPTION
This PR just changes the way units are printed when they are translated into characters. Instead of being shown as sequences of multiplication, such as `m*m*m`, they are shown as powers, `m^3`.
